### PR TITLE
Making NovaPermissionTool customizable

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -29,7 +29,9 @@ class ToolServiceProvider extends ServiceProvider
 
         Nova::serving(function (ServingNova $event) {
             Nova::tools([
-                new \Vyuldashev\NovaPermission\NovaPermissionTool,
+                \Vyuldashev\NovaPermission\NovaPermissionTool::make()
+                ->roleResource(config('multitenancy.custom_resources.role') ?: \Vyuldashev\NovaPermission\Role::class)
+                ->permissionResource(config('multitenancy.custom_resources.permission') ?: \Vyuldashev\NovaPermission\Permission::class),
             ]);
         });
 


### PR DESCRIPTION
This modification enable **vyuldashev/nova-permission** to be customizable and enable possible to apply BelongsToTenant trait defining a custom model to make all rules and permissions filtered by tenant.
